### PR TITLE
fix: use github.ref_name instead

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,6 @@ jobs:
           heighliner-tag: v1.6.4
           github-organization: ${{ github.repository_owner }}
           github-repo: ${{ github.event.repository.name }}
-          git-ref: ${{ github.event.inputs.release_tag || github.ref }}
+          git-ref: ${{ github.event.inputs.release_tag || github.ref_name }}
           registry: ghcr.io/${{ env.OWNER_LC }}
           skip: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the clarity and reliability of the Docker workflow by modifying how the Git reference is determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->