### PR TITLE
chore: remove unnecessary ci jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,3 @@ updates:
     directory: "/tests/connect"
     schedule:
       interval: daily
-  - package-ecosystem: gomod
-    directory: "/tests/feemarket"
-    schedule:
-      interval: daily

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,63 +3,20 @@
   - changed-files:
       - any-glob-to-any-file:
           - app/*.go
-          - app/apptesting/**
-          - app/keepers/**
           - app/params/**
-          - app/upgrades/**
-          - x/**/module.go
-"C:wasm":
+          - app/queries/**
+"C:x/tax":
   - changed-files:
       - any-glob-to-any-file:
-          - wasmbinding/**
-"C:x/guard":
+          - x/tax/**
+"C:x/tokenfactory":
   - changed-files:
       - any-glob-to-any-file:
-          - x/guard/**
-"C:x/txfees":
+          - x/tokenfactory/**
+"C:x/xfeemarket":
   - changed-files:
       - any-glob-to-any-file:
-          - x/txfees/**
-"C:x/airdrop":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/airdrop/**
-"C:x/bridge":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/bridge/**
-"C:x/coinfactory":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/coinfactory/**
-"C:x/did":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/did/**
-"C:x/farming":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/farming/**
-"C:x/liquidity":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/liquidity/**
-"C:x/lpfarm":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/lpfarm/**
-"C:x/marketmaker":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/marketmaker/**
-"C:x/rewards":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/rewards/**
-"C:x/token":
-  - changed-files:
-      - any-glob-to-any-file:
-          - x/token/**
+          - x/xfeemarket/**
 
 "T:build":
   - changed-files:
@@ -78,6 +35,7 @@
       - any-glob-to-any-file:
           - client/**
           - x/*/client/**
+          - x/**/autocli.go
 "C:docs":
   - changed-files:
       - any-glob-to-any-file:
@@ -88,3 +46,4 @@
           - x/**/*.md
           - x/**/*/*.md
           - tests/**/*.md
+          - adr/*.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,11 @@ on:
 name: Build and validate genesis
 jobs:
   build:
-    strategy:
-      matrix:
-        go-version: [1.23.x]
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.23
       - uses: actions/checkout@v4
       - name: install
         run: make install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,17 +13,13 @@ permissions:
 
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go: [stable]
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     name: lint
-    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 1.23
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -6,14 +6,10 @@ on:
 name: Unit Tests
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.23.x]
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.23
       - uses: actions/checkout@v4
       - run: go test ./...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Simplified workflow configurations for build, lint, and test jobs by removing matrix strategies.
	- Standardized environment to `ubuntu-latest` and fixed Go version to `1.23` across all workflows.
	- Updated Dependabot configuration by removing specific monitoring for the "gomod" ecosystem in one directory.
	- Reorganized labeler configuration to reflect changes in file tracking, adding new categories and removing outdated ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->