### PR TITLE
feat: increase max-wasm-size to 3mb

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -273,6 +273,14 @@ type App struct {
 	configurator module.Configurator
 }
 
+// overrideWasmVariables overrides the wasm variables to:
+//   - allow for larger wasm files
+func overrideWasmVariables() {
+	// Override Wasm size limitation from WASMD.
+	wasmtypes.MaxWasmSize = 3 * 1024 * 1024
+	wasmtypes.MaxProposalWasmSize = wasmtypes.MaxWasmSize
+}
+
 // New returns a reference to an initialized App.
 func New(
 	logger log.Logger,
@@ -283,6 +291,7 @@ func New(
 	wasmOpts []wasmkeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
+	overrideWasmVariables()
 	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles: proto.HybridResolver,
 		SigningOptions: signing.Options{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased support for WebAssembly files by raising the processing limit to 3 MB, allowing for the handling of larger and more complex modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->