### PR TITLE
feat: block mint burn for disabled tokenfactory coins

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information on the architecture and design decisions, please refer to t
 
 Mantrachain includes several custom modules:
 
-- `x/xfeemarket`: Extends the fee market functionality to support multiple fee tokens.
+- `x/sanction`: Blacklisting of addresses to prevent transactions from sanctioned entities.
 - `x/tokenfactory`: Allows for the creation and management of new tokens (based on Neutron's implementation).
 - `x/tax`: Handles tax-related operations within the chain.
 

--- a/tests/e2e/e2e_sanction_test.go
+++ b/tests/e2e/e2e_sanction_test.go
@@ -43,7 +43,7 @@ func (s *IntegrationTestSuite) testAddToBlacklist() {
 	chainEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
 
 	validatorA := s.chainA.validators[0]
-	validatorAAddr, _ := validatorA.keyInfo.GetAddress()
+	validatorAddr, _ := validatorA.keyInfo.GetAddress()
 
 	valIdx := 0
 	alice, _ := s.chainA.genesisAccounts[1].keyInfo.GetAddress()
@@ -59,7 +59,7 @@ func (s *IntegrationTestSuite) testAddToBlacklist() {
 
 	s.T().Logf("Proposal number: %d", proposalCounter)
 	s.T().Logf("Submitting, deposit and vote Gov Proposal: Add %s to blacklist", alice.String())
-	s.submitGovProposal(chainEndpoint, validatorAAddr.String(), proposalCounter, "sanctiontypes.MsgAddBlacklistAccounts", submitGovFlags, depositGovFlags, voteGovFlags, "vote")
+	s.submitGovProposal(chainEndpoint, validatorAddr.String(), proposalCounter, "sanctiontypes.MsgAddBlacklistAccounts", submitGovFlags, depositGovFlags, voteGovFlags, "vote")
 
 	s.Require().Eventually(
 		func() bool {

--- a/tests/e2e/query.go
+++ b/tests/e2e/query.go
@@ -93,6 +93,20 @@ func querySupplyOf(endpoint, denom string) (sdk.Coin, error) {
 	return supplyOfResp.Amount, nil
 }
 
+func querySendEnabled(endpoint string) ([]*banktypes.SendEnabled, error) {
+	body, err := httpGet(fmt.Sprintf("%s/cosmos/bank/v1beta1/send_enabled", endpoint))
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+
+	var sendEnabledResp banktypes.QuerySendEnabledResponse
+	if err := cdc.UnmarshalJSON(body, &sendEnabledResp); err != nil {
+		return nil, err
+	}
+
+	return sendEnabledResp.SendEnabled, nil
+}
+
 // func queryStakingParams(endpoint string) (stakingtypes.QueryParamsResponse, error) {
 // 	body, err := httpGet(fmt.Sprintf("%s/cosmos/staking/v1beta1/params", endpoint))
 // 	if err != nil {

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -53,6 +53,10 @@ func (server msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if !server.bankKeeper.IsSendEnabledDenom(ctx, msg.Amount.Denom) {
+		return nil, types.ErrInvalidDenom.Wrapf("%s has been disabled", msg.Amount.Denom)
+	}
+
 	// pay some extra gas cost to give a better error here.
 	_, denomExists := server.bankKeeper.GetDenomMetaData(ctx, msg.Amount.Denom)
 	if !denomExists {
@@ -94,6 +98,10 @@ func (server msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if !server.bankKeeper.IsSendEnabledDenom(ctx, msg.Amount.Denom) {
+		return nil, types.ErrInvalidDenom.Wrapf("%s has been disabled", msg.Amount.Denom)
+	}
 
 	authorityMetadata, err := server.Keeper.GetAuthorityMetadata(ctx, msg.Amount.GetDenom())
 	if err != nil {

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -22,6 +22,8 @@ type BankKeeper interface {
 
 	SendCoins(ctx context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
 	HasBalance(ctx context.Context, addr sdk.AccAddress, amt sdk.Coin) bool
+
+	IsSendEnabledDenom(ctx context.Context, denom string) bool
 }
 
 type AccountKeeper interface {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to disable and reenable sending for specific token denominations via governance proposals in the token factory module.
  * Introduced checks to prevent minting or burning tokens for denominations with sending disabled.

* **Bug Fixes**
  * Improved variable naming in sanction-related tests for clarity.

* **Documentation**
  * Updated the README to reflect changes in module descriptions, specifically replacing references to fee market with sanction module details.

* **Tests**
  * Expanded end-to-end tests to cover governance proposals for send-enabled status, and integrated these checks into minting and burning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->