### PR TITLE
fix: register geth core precompiles

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -757,6 +758,7 @@ func New(
 	// app.IBCKeeper.SetRouterV2(ibcRouterV2)
 
 	// TODO: Configure EVM precompiles when needed
+	corePrecompiles := maps.Clone(corevm.PrecompiledContractsBerlin)
 	// corePrecompiles := NewAvailableStaticPrecompiles(
 	// 	app.StakingKeeper,
 	// 	app.DistrKeeper,
@@ -770,9 +772,9 @@ func New(
 	// 	app.EvidenceKeeper,
 	// 	appCodec,
 	// )
-	// app.EVMKeeper.WithStaticPrecompiles(
-	// 	corePrecompiles,
-	// )
+	app.EVMKeeper.WithStaticPrecompiles(
+		corePrecompiles,
+	)
 
 	storeProvider := app.IBCKeeper.ClientKeeper.GetStoreProvider()
 	tmLightClientModule := ibctm.NewLightClientModule(appCodec, storeProvider)


### PR DESCRIPTION
fix error: `precompiled contract not stored in memory`.

the [IsAvailableStaticPrecompile](https://github.com/cosmos/evm/blob/main/x/vm/keeper/static_precompiles.go#L44) checks the address against `vm.PrecompiledAddressesBerlin` which is core geth precompiles, but in app.go we didn't register them.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the use of Ethereum Berlin precompiled contracts within the EVM module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->