### PR TITLE
Problem: non-eip155 tx in evm ecosystem not support

### DIFF
--- a/app/upgrades/v5rc3/upgrades.go
+++ b/app/upgrades/v5rc3/upgrades.go
@@ -34,6 +34,11 @@ func CreateUpgradeHandler(
 			}
 		}
 
+		// enable AllowUnprotectedTxs see adr-006
+		params := keepers.EVMKeeper.GetParams(ctx)
+		params.AllowUnprotectedTxs = true
+		keepers.EVMKeeper.SetParams(ctx, params)
+
 		ctx.Logger().Info("Upgrade v5.0.0-rc3 complete")
 		return vm, nil
 	}


### PR DESCRIPTION
there are some common practices in evm ecosystem that requires non-eip155 transactions to work.

see adr-006.