### PR TITLE
Chore: switch ci to use own github runner system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 name: Build
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_links:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cleanup-image.yml
+++ b/.github/workflows/cleanup-image.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   delete-tagged-images:
     name: Delete Specific Tagged Images
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     permissions:
       packages: write
     steps:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest-xlarge') || 'ubuntu-latest' }}
+    runs-on: sandbox-asia-east2
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         go-version: [1.23.x]
         os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: DevSkim
-    runs-on: ubuntu-24.04
+    runs-on: sandbox-asia-east2
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   heighliner-docker:
-    runs-on: ubuntu-latest-x64-xlarge
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Gosec:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -7,7 +7,7 @@ on:
 name: Run govulncheck
 jobs:
   govulncheck_job:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - id: govulncheck
         uses: golang/govulncheck-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   golangci:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     name: lint
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   on-failure:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
     steps:
       - uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     name: Build - ${{ matrix.platform.name }}
-    runs-on: ${{ matrix.platform.runner || 'chain-runner' }}
+    runs-on: sandbox-asia-east2
     strategy:
       matrix:
         platform:
@@ -75,7 +75,7 @@ jobs:
     if: github.event_name != 'pull_request'
     name: Create release
     needs: [build]
-    runs-on: chain-runner
+    runs-on: sandbox-asia-east2
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/tests-e2e-nix.yml
+++ b/.github/workflows/tests-e2e-nix.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   integration_tests:
-    runs-on: ubuntu-latest-x64-xlarge
+    runs-on: sandbox-asia-east2
     timeout-minutes: 240
     strategy:
       matrix:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -6,7 +6,7 @@ on:
 name: E2E Tests
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/tests-sdk.yml
+++ b/.github/workflows/tests-sdk.yml
@@ -6,7 +6,7 @@ on:
 name: SDK Tests
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -6,7 +6,7 @@ on:
 name: Unit Tests
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: sandbox-asia-east2
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to use a custom runner, `sandbox-asia-east2`, instead of the various default GitHub-hosted runners. This change standardizes the CI/CD environment across all workflows, which can help with consistency, performance, and possibly cost control.

**Runner changes across workflows:**

* All workflows now use `sandbox-asia-east2` as the `runs-on` value, replacing previous values such as `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-latest-x64-xlarge`, and custom matrix runners. This affects workflows for build, test, lint, security, release, notifications, and cleanup. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L10-R10) [[2]](diffhunk://#diff-25a643f425941ca778a38c964820dd72fd45d3e72b8c65271e9d013eda82d37aL10-R10) [[3]](diffhunk://#diff-861caa8883067db55d202ff4e4d20aa6b6cf8d370560b57a6a466fc924d0ee45L14-R14) [[4]](diffhunk://#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9L7-R7) [[5]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L30-R30) [[6]](diffhunk://#diff-ebd11c3b2d70c295d0052fcde8438659bab57512db77b3080bb0db90364aeaf7L14-R14) [[7]](diffhunk://#diff-cf9c7e0ae50cd2d73f48fc95d5f4784c87b4932f23c9bf60f2223ef12262c4cdL19-R19) [[8]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L27-R27) [[9]](diffhunk://#diff-d8571350f01817cad9aa4ce082793192f034e5262ce8dd44dde00af21624298bL12-R12) [[10]](diffhunk://#diff-a55a9ce2657705a223e919a04ae05d12e6c8b247263c7cd93be19dff507c8efdL10-R10) [[11]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L16-R16) [[12]](diffhunk://#diff-69e27caedf999cef228794d443d4a7380db02cde95ceee548012bd81d2ea225fL10-R10) [[13]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L25-R25) [[14]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L78-R78) [[15]](diffhunk://#diff-01ffc8543d42aa115a74d9192ca7d88ccc0ccebc8ee6d12bf319f28e343fb328L15-R15) [[16]](diffhunk://#diff-e3bc0bb999804209239f7b4244cdbdbae7a6e73abd7f452bf93ac90cd0074a1fL9-R9) [[17]](diffhunk://#diff-0eed960b3db8ebec90b6211027552a0c007c5d993d7f9b8d8dee68534fb336e8L9-R9) [[18]](diffhunk://#diff-d605b8b643442c4794a8ed0d439559c5679b210dc4c7e82480ded477d1a76e99L9-R9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized all CI workflows to run on a unified sandbox-asia-east2 runner, covering build, release, link checks, image cleanup, code coverage, code scanning, security checks, linting, notifications, and all test suites (unit, SDK, E2E, Nix).
  - Improves consistency, isolation, and reliability of pipeline execution without altering steps, triggers, or job logic.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->