### PR TITLE
chore: read chain ID from app.toml before genesis

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -78,9 +78,10 @@ func setBaseDenom(ci evmtypes.EvmCoinInfo) error {
 
 var (
 	EVMChainIDMap = map[string]uint64{
-		"mantra-1":            5888, // mainnet Chain ID
-		"mantra-dukong-1":     5887, // testnet Chain ID
-		"mantra-canary-net-1": 7888, // devnet Chain ID
+		"mantra-1":            5888,   // mainnet Chain ID
+		"mantra-dukong-1":     5887,   // testnet Chain ID
+		"mantra-canary-net-1": 7888,   // devnet Chain ID
+		"mantra-dryrun-1":     262144, // dryrun Chain ID
 	}
 
 	MANTRAChainID uint64 = 262144 // default Chain ID


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now prefers the EVM chain ID from app.toml when present; otherwise it will attempt to derive and parse a chain ID from genesis later in initialization.
  * Improved parsing and validation: invalid derived chain IDs now cause startup to fail early with a clear error.

* **Existing**
  * Support for “mantra-dryrun-1” (Chain ID 262144) remains available and unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->