### PR TITLE
fix: check missing parent gas meter

### DIFF
--- a/x/tokenfactory/types/proxygasmeter.go
+++ b/x/tokenfactory/types/proxygasmeter.go
@@ -23,6 +23,10 @@ type ProxyGasMeter struct {
 //
 // If limit is greater than or equal to the remaining gas, no wrapping is needed and the original gas meter is returned.
 func NewProxyGasMeter(gasMeter storetypes.GasMeter, limit storetypes.Gas) storetypes.GasMeter {
+	if gasMeter == nil {
+		panic("cannot create ProxyGasMeter with nil parent gas meter")
+	}
+
 	if limit >= gasMeter.GasRemaining() {
 		return gasMeter
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added strict validation for gas metering configuration to prevent running with an invalid (nil) parent meter. The system now fails fast with a clear error when misconfigured, improving reliability.
  * Ensures consistent gas accounting by rejecting invalid setups early, reducing the risk of subtle runtime issues and making misconfiguration easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->