### PR TITLE
ci(release): add github attestation on the binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,6 @@ jobs:
           GORELEASER_SKIP: validate
           GORELEASER_CONFIG: ./scripts/ci-goreleaser/.goreleaser.yaml
       - name: Generate SLSA provenance
-        if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ env:
 
 permissions:
   contents: write
+  attestations: write       # added (to publish provenance)
+  id-token: write           # (required for OIDC token used by attest-build-provenance)
 
 jobs:
   build:
@@ -104,3 +106,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_SKIP: validate
           GORELEASER_CONFIG: ./scripts/ci-goreleaser/.goreleaser.yaml
+      - name: Generate SLSA provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            dist/*/mantrachaind*
+            dist/*.tar.gz
+            dist/sha256sum.txt


### PR DESCRIPTION
### Goal

Provide a way for validators and other users to verify a binary

### How
Leverage Github's Attestation mechanism, which following SLSA standard.

### Tests
This PR was testing on the following fork: https://github.com/MANTRA-Chain/mantrachain-yohan-signing
Job: https://github.com/MANTRA-Chain/mantrachain-yohan-signing/actions/runs/18092993800

It created this release :
<img width="1201" height="984" alt="image" src="https://github.com/user-attachments/assets/c34ed1c4-462a-452c-b02d-3ec86efe8fc0" />

This attestation (link output in the job summary): https://github.com/MANTRA-Chain/mantrachain-yohan-signing/attestations/11242009


We can well verify it using:
<img width="918" height="662" alt="image" src="https://github.com/user-attachments/assets/25b41b0d-fc75-4782-bfba-af1eb4c6febc" />


### Getting started for users
1. To verify, download the binary
2. Then, run:

```
gh attestation verify --repo MANTRA-Chain/mantrachain <binary-file>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to generate verifiable provenance (SLSA) for distributed artifacts, improving supply-chain transparency and trust in release builds.
  * Updated CI permissions to enable secure artifact attestation and identity-based signing, strengthening the integrity of published releases.
  * No changes to application functionality; these updates affect the release process only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->