### PR TITLE
Problem: static precompiles are not enabled

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -784,19 +783,19 @@ func New(
 	app.IBCKeeper.SetRouter(ibcRouter)
 
 	// TODO: Configure EVM precompiles when needed
-	corePrecompiles := maps.Clone(corevm.PrecompiledContractsPrague)
-	// corePrecompiles := evmd.NewAvailableStaticPrecompiles(
-	// 	app.StakingKeeper,
-	// 	app.DistrKeeper,
-	// 	app.PreciseBankKeeper,
-	// 	app.Erc20Keeper,
-	// 	app.TransferKeeper,
-	// 	app.IBCKeeper.ChannelKeeper,
-	// 	app.EVMKeeper,
-	// 	app.GovKeeper,
-	// 	app.SlashingKeeper,
-	// 	app.AppCodec(),
-	// )
+	// corePrecompiles := maps.Clone(corevm.PrecompiledContractsPrague)
+	corePrecompiles := evmd.NewAvailableStaticPrecompiles(
+		app.StakingKeeper,
+		app.DistrKeeper,
+		app.PreciseBankKeeper,
+		app.Erc20Keeper,
+		app.TransferKeeper,
+		app.IBCKeeper.ChannelKeeper,
+		app.EVMKeeper,
+		app.GovKeeper,
+		app.SlashingKeeper,
+		app.AppCodec(),
+	)
 	app.EVMKeeper.WithStaticPrecompiles(
 		corePrecompiles,
 	)

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/MANTRA-Chain/cosmos-sdk v0.53.3-v5-mantra-1
 
 	// Direct tag link: https://github.com/MANTRA-Chain/evm/tree/mantra/v0.4.x_main
-	github.com/cosmos/evm => github.com/MANTRA-Chain/evm v0.0.0-20250821011959-cdd966c0f14a
-	github.com/cosmos/evm/evmd => github.com/MANTRA-Chain/evm/evmd v0.0.0-20250821011959-cdd966c0f14a
+	github.com/cosmos/evm => github.com/MANTRA-Chain/evm v0.0.0-20251006011224-d351dd18dbbc
+	github.com/cosmos/evm/evmd => github.com/MANTRA-Chain/evm/evmd v0.0.0-20251006011224-d351dd18dbbc
 
 	// branch: release/1.16
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.16.2-cosmos-1

--- a/go.sum
+++ b/go.sum
@@ -704,10 +704,10 @@ github.com/MANTRA-Chain/connect/v2 v2.3.0-mantra-1.3 h1:qWZ+EINMBkB0DqOE90M18SCx
 github.com/MANTRA-Chain/connect/v2 v2.3.0-mantra-1.3/go.mod h1:tujhWIP46K4z5l5Swqxyurakq1+sq14RtHfkVHrZSPU=
 github.com/MANTRA-Chain/cosmos-sdk v0.53.3-v5-mantra-1 h1:WqmQ6SxaYGbWKSdGieDiCHo4IruicYy8H1ehfZ7gnUM=
 github.com/MANTRA-Chain/cosmos-sdk v0.53.3-v5-mantra-1/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
-github.com/MANTRA-Chain/evm v0.0.0-20250821011959-cdd966c0f14a h1:WW0R4UTzSZgKm+F69uXGKoBChezUtY90gqso3XI+MwY=
-github.com/MANTRA-Chain/evm v0.0.0-20250821011959-cdd966c0f14a/go.mod h1:qGQKXU9zuuiNsJ9qybv/DeGV1BwpPacXuupTE9OiSnA=
-github.com/MANTRA-Chain/evm/evmd v0.0.0-20250821011959-cdd966c0f14a h1:OY98diOpPbqx6yY9KctYYEP43RwNqlL2ekmr2okVxcQ=
-github.com/MANTRA-Chain/evm/evmd v0.0.0-20250821011959-cdd966c0f14a/go.mod h1:tMPfFP9xQ0DGZkrJYCFeSPtOPmEjSMcSzRMbq9Hx/7Y=
+github.com/MANTRA-Chain/evm v0.0.0-20251006011224-d351dd18dbbc h1:J2j5o+GqrxDXTfRwonEfz8QS/wHKAhun47CQDcZmYrg=
+github.com/MANTRA-Chain/evm v0.0.0-20251006011224-d351dd18dbbc/go.mod h1:qGQKXU9zuuiNsJ9qybv/DeGV1BwpPacXuupTE9OiSnA=
+github.com/MANTRA-Chain/evm/evmd v0.0.0-20251006011224-d351dd18dbbc h1:6kDBtKLU+wywy6/1h+cS5dpvEp9/rdZPEOrwdDWg+HI=
+github.com/MANTRA-Chain/evm/evmd v0.0.0-20251006011224-d351dd18dbbc/go.mod h1:tMPfFP9xQ0DGZkrJYCFeSPtOPmEjSMcSzRMbq9Hx/7Y=
 github.com/MANTRA-Chain/wasmd v0.0.0-20250724044732-5d3a4a2c160d h1:/GNezpHU/5vbaSG1cHR+13dUngQcF4hXZRIJSapBbxA=
 github.com/MANTRA-Chain/wasmd v0.0.0-20250724044732-5d3a4a2c160d/go.mod h1:IPNcIpwClf0iJamkYG3FCdgX1vAUzgoGv85fgmbNSB0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
test in https://github.com/MANTRA-Chain/mantrachain-e2e/pull/88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated EVM static precompiles initialization to use the latest initialization path for better stability and compatibility with the updated EVM stack.
* **Chores**
  * Upgraded EVM-related dependencies to the newest MANTRA-Chain forks to improve performance and ecosystem compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->