### PR TITLE
Problem: not set disable list of wasm breaker in upgrade

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -88,6 +88,9 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -267,6 +270,7 @@ type App struct {
 	CrisisKeeper          *crisiskeeper.Keeper //nolint:staticcheck
 	UpgradeKeeper         *upgradekeeper.Keeper
 	ParamsKeeper          paramskeeper.Keeper //nolint:staticcheck
+	AuthzKeeper           authzkeeper.Keeper
 	EvidenceKeeper        evidencekeeper.Keeper
 	FeeGrantKeeper        feegrantkeeper.Keeper
 	NFTKeeper             nftkeeper.Keeper
@@ -377,6 +381,7 @@ func New(
 		govtypes.StoreKey, paramstypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
 		evidencetypes.StoreKey,
 		circuittypes.StoreKey,
+		authzkeeper.StoreKey,
 		nftkeeper.StoreKey,
 		// non sdk store keys
 		ibcexported.StoreKey, ibctransfertypes.StoreKey,
@@ -506,6 +511,13 @@ func New(
 		app.AccountKeeper.AddressCodec(),
 	)
 	app.SetCircuitBreaker(&app.CircuitKeeper)
+
+	app.AuthzKeeper = authzkeeper.NewKeeper(
+		runtime.NewKVStoreService(keys[authzkeeper.StoreKey]),
+		appCodec,
+		app.MsgServiceRouter(),
+		app.AccountKeeper,
+	)
 
 	// get skipUpgradeHeights from the app options
 	skipUpgradeHeights := map[int64]bool{}
@@ -887,6 +899,7 @@ func New(
 		upgrade.NewAppModule(app.UpgradeKeeper, app.AccountKeeper.AddressCodec()),
 		evidence.NewAppModule(app.EvidenceKeeper),
 		params.NewAppModule(app.ParamsKeeper), //nolint:staticcheck
+		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		nftmodule.NewAppModule(appCodec, app.NFTKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		consensus.NewAppModule(appCodec, app.ConsensusParamsKeeper),
 		circuit.NewAppModule(appCodec, app.CircuitKeeper),
@@ -960,6 +973,7 @@ func New(
 		evidencetypes.ModuleName,
 		stakingtypes.ModuleName,
 		genutiltypes.ModuleName,
+		authz.ModuleName,
 		govtypes.ModuleName,
 		crisistypes.ModuleName,
 		// additional non simd modules
@@ -1018,6 +1032,7 @@ func New(
 		minttypes.ModuleName,
 		crisistypes.ModuleName,
 		evidencetypes.ModuleName,
+		authz.ModuleName,
 		feegrant.ModuleName,
 		nft.ModuleName,
 		paramstypes.ModuleName,
@@ -1452,6 +1467,7 @@ func (app *App) setupUpgradeHandlers() {
 					BankKeeper:         app.BankKeeper,
 					EVMKeeper:          *app.EVMKeeper,
 					Erc20Keeper:        app.Erc20Keeper,
+					CircuitKeeper:      app.CircuitKeeper,
 				},
 				app.keys,
 			),

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -2,6 +2,7 @@ package upgrades
 
 import (
 	storetypes "cosmossdk.io/store/types"
+	circuitkeeper "cosmossdk.io/x/circuit/keeper"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sanctionkeeper "github.com/MANTRA-Chain/mantrachain/v6/x/sanction/keeper"
 	tokenfactorykeeper "github.com/MANTRA-Chain/mantrachain/v6/x/tokenfactory/keeper"
@@ -59,4 +60,5 @@ type UpgradeKeepers struct {
 	BankKeeper      bankkeeper.BaseKeeper
 	EVMKeeper       evmkeeper.Keeper
 	Erc20Keeper     erc20keeper.Keeper
+	CircuitKeeper   circuitkeeper.Keeper
 }

--- a/app/upgrades/v6rc0/constants.go
+++ b/app/upgrades/v6rc0/constants.go
@@ -15,6 +15,6 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: types.StoreUpgrades{
 		Added:   []string{},
-		Deleted: []string{"authz", "group"},
+		Deleted: []string{"group"},
 	},
 }

--- a/app/upgrades/v6rc0/upgrades.go
+++ b/app/upgrades/v6rc0/upgrades.go
@@ -31,6 +31,15 @@ func CreateUpgradeHandler(
 			}
 		}
 
+		disableList := []string{
+			"wasm/cosmos.evm.erc20.v1.MsgRegisterERC20",
+			"wasm/cosmos.authz.v1beta1.MsgExec",
+		}
+		for _, msg := range disableList {
+			if err := keepers.CircuitKeeper.DisableList.Set(ctx, msg); err != nil {
+				return vm, err
+			}
+		}
 		ctx.Logger().Info("Upgrade v6.0.0-rc0 complete")
 		return vm, nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the Cosmos Authz module, enabling delegated permissions (grant/exec/revoke) for actions across accounts.

- Chores
  - Upgrade flow enhanced with circuit-breaker protections that disable select wasm messages during the v6rc0 upgrade to improve network safety.
  - Upgrade ordering and module activation updated to include Authz, ensuring consistent initialization and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->