### PR TITLE
Problem: magic nix cache is not used

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,14 +138,8 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
         if: steps.changed-files.outputs.only_changed == 'false'
-      - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12
+      - uses: DeterminateSystems/magic-nix-cache-action@main
         if: steps.changed-files.outputs.only_changed == 'false'
-        with:
-          name: mantrachain-e2e
-          extraPullNames: dapp
-          # github don't pass secrets for pull request from fork repos,
-          # in that case the push is disabled naturally.
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Checkout mantrachain-e2e
         if: steps.changed-files.outputs.only_changed == 'false'
         uses: actions/checkout@v4
@@ -169,6 +163,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: debug-files
+          name: debug-files-${{ matrix.tests }}
           path: mantrachain-e2e/debug_files.tar.gz
           if-no-files-found: ignore


### PR DESCRIPTION
make ci faster and no secrets required with automatic cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded continuous integration pipeline with improved caching mechanisms for faster builds
  * Updated artifact naming and management to better organize test outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->