### PR TITLE
Problem: sandbox is not set to build hermes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-24.11
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            sandbox = false
         if: steps.changed-files.outputs.only_changed == 'false'
       - uses: DeterminateSystems/magic-nix-cache-action@main
         if: steps.changed-files.outputs.only_changed == 'false'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to adjust sandbox settings for the Nix test environment, optimizing test execution parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->