### PR TITLE
ci(mergify): add 7.0.0-rcx backport

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -82,6 +82,14 @@ pull_request_rules:
       backport:
         branches:
           - release/v6.1.x
+  - name: backport patches to release/v7.0.0-rcx branch
+    conditions:
+      - base=main
+      - label=A:backport/v7.0.0-rcx
+    actions:
+      backport:
+        branches:
+          - release/v7.0.0-rcx
   - name: backport patches to release/v7.0.x branch
     conditions:
       - base=main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release automation to enable automatic backporting of eligible pull requests to the v7.0.0-rcx release candidate branch when labeled for backporting, expanding the set of release branches that can receive patched fixes alongside existing targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->