### PR TITLE
Problem: start oracle client and ABCI wiring when disabled

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,4 +13,5 @@ jobs:
         uses: golang/govulncheck-action@v1
         with:
           go-package: ./...
+          go-version-file: go.mod
           check-latest: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Return original error if no evm chain-id found ([#582](https://github.com/MANTRA-Chain/mantrachain/pull/582))
 - Reject malformed tx bytes in ProcessProposal when EVM mempool is enabled ([#593](https://github.com/MANTRA-Chain/mantrachain/pull/593))
+- Skip oracle client startup and oracle ABCI preblock or vote-extension wiring when disabled. ([#601](https://github.com/MANTRA-Chain/mantrachain/pull/601))
 
 
 ## v7.0.0

--- a/app/app.go
+++ b/app/app.go
@@ -1175,17 +1175,25 @@ func New(
 	// configure mempool
 	prepareProposalHandler, processProposalHandler := app.configureEVMMempool(appOpts, logger)
 
-	// oracle initialization
-	client, metrics, err := app.initializeOracle(appOpts)
+	oracleEnabled, err := app.isOracleEnabled(appOpts)
 	if err != nil {
-		panic(fmt.Errorf("failed to initialize oracle client and metrics: %w", err))
+		panic(fmt.Errorf("failed to read oracle config: %w", err))
 	}
 
-	app.MarketMapKeeper.SetHooks(app.OracleKeeper.Hooks())
+	if oracleEnabled {
+		client, metrics, err := app.initializeOracle(appOpts)
+		if err != nil {
+			panic(fmt.Errorf("failed to initialize oracle client and metrics: %w", err))
+		}
 
-	prepareProposalHandler, processProposalHandler = app.initializeABCIExtensions(
-		client, metrics, prepareProposalHandler, processProposalHandler,
-	)
+		app.MarketMapKeeper.SetHooks(app.OracleKeeper.Hooks())
+
+		prepareProposalHandler, processProposalHandler = app.initializeABCIExtensions(
+			client, metrics, prepareProposalHandler, processProposalHandler,
+		)
+	} else {
+		app.Logger().Info("oracle is disabled, skipping oracle ABCI extension wiring")
+	}
 
 	app.SetPrepareProposal(prepareProposalHandler)
 	app.SetProcessProposal(processProposalHandler)

--- a/app/oracle.go
+++ b/app/oracle.go
@@ -26,6 +26,11 @@ func (app *App) initializeOracle(appOpts types.AppOptions) (oracleclient.OracleC
 		return nil, nil, err
 	}
 
+	if !cfg.Enabled {
+		app.Logger().Info("oracle is disabled, skipping oracle client startup")
+		return nil, nil, nil
+	}
+
 	// If app level instrumentation is enabled, then wrap the oracle service with a metrics client
 	// to get metrics on the oracle service (for ABCI++). This will allow the instrumentation to track
 	// latency in VerifyVoteExtension requests and more.
@@ -54,6 +59,15 @@ func (app *App) initializeOracle(appOpts types.AppOptions) (oracleclient.OracleC
 	}()
 
 	return oracleClient, oracleMetrics, nil
+}
+
+func (app *App) isOracleEnabled(appOpts types.AppOptions) (bool, error) {
+	cfg, err := oracleconfig.ReadConfigFromAppOpts(appOpts)
+	if err != nil {
+		return false, err
+	}
+
+	return cfg.Enabled, nil
 }
 
 func (app *App) initializeABCIExtensions(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle functionality can now be disabled via application configuration. When disabled, oracle client startup and ABCI extension wiring are automatically skipped.

* **Bug Fixes**
  * Improved error messaging for oracle configuration read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->