### PR TITLE
Problem: over clamping in fixSilentlySkippedSlashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### BUG-FIXES
 
 - Fix stale staking keeper for slashing/evidence and upgrade v8.1.0 to clamp `DelegatorStartingInfo.Stake` left over from v8.0.0 hook-skip window, and align bank keeper to a pointer so TokenFactory `BeforeSend` hooks reach Provider's `SendCoinsFromModuleToModule` ([#654](https://github.com/MANTRA-Chain/mantrachain/pull/654))
+- Skip recorded `ValidatorSlashEvent`s when clamping `DelegatorStartingInfo.Stake` to avoid double-attenuating rewards ([#655](https://github.com/MANTRA-Chain/mantrachain/pull/655))
 
 ## v8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## [unreleased]
+## v8.1.1
+
+*May 1, 2026*
+
+### BUG-FIXES
+
+- Skip recorded `ValidatorSlashEvent`s when clamping `DelegatorStartingInfo.Stake` to avoid double-attenuating rewards ([#655](https://github.com/MANTRA-Chain/mantrachain/pull/655))
+
 ## v8.1.0
 
 *April 30, 2026*
@@ -6,7 +14,6 @@
 ### BUG-FIXES
 
 - Fix stale staking keeper for slashing/evidence and upgrade v8.1.0 to clamp `DelegatorStartingInfo.Stake` left over from v8.0.0 hook-skip window, and align bank keeper to a pointer so TokenFactory `BeforeSend` hooks reach Provider's `SendCoinsFromModuleToModule` ([#654](https://github.com/MANTRA-Chain/mantrachain/pull/654))
-- Skip recorded `ValidatorSlashEvent`s when clamping `DelegatorStartingInfo.Stake` to avoid double-attenuating rewards ([#655](https://github.com/MANTRA-Chain/mantrachain/pull/655))
 
 ## v8.0.0
 

--- a/app/upgrades/v8_1/constants.go
+++ b/app/upgrades/v8_1/constants.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// UpgradeName defines the on-chain upgrade name.
-	UpgradeName = "v8.1.0"
+	UpgradeName = "v8.1.1"
 )
 
 var Upgrade = upgrades.Upgrade{

--- a/app/upgrades/v8_1/distribution.go
+++ b/app/upgrades/v8_1/distribution.go
@@ -49,7 +49,7 @@ func fixSilentlySkippedSlashes(
 		}
 		if validator == nil {
 			logger.Warn(
-				"v8.1.0: validator missing for delegator starting info; skipping",
+				"v8.1.1: validator missing for delegator starting info; skipping",
 				"validator", val.String(),
 				"delegator", del.String(),
 			)
@@ -62,7 +62,7 @@ func fixSilentlySkippedSlashes(
 		}
 		if delegation == nil {
 			logger.Warn(
-				"v8.1.0: delegation missing for delegator starting info; skipping",
+				"v8.1.1: delegation missing for delegator starting info; skipping",
 				"validator", val.String(),
 				"delegator", del.String(),
 			)
@@ -106,7 +106,7 @@ func fixSilentlySkippedSlashes(
 
 	for _, f := range fixes {
 		logger.Info(
-			"v8.1.0: clamping silent-skip residue on delegator starting info",
+			"v8.1.1: clamping silent-skip residue on delegator starting info",
 			"validator", f.val.String(),
 			"delegator", f.del.String(),
 			"old_stake", f.info.Stake.String(),
@@ -118,6 +118,6 @@ func fixSilentlySkippedSlashes(
 		}
 	}
 
-	logger.Info("v8.1.0: fixed silently-skipped slashes", "entries_updated", len(fixes))
+	logger.Info("v8.1.1: fixed silently-skipped slashes", "entries_updated", len(fixes))
 	return nil
 }

--- a/app/upgrades/v8_1/distribution.go
+++ b/app/upgrades/v8_1/distribution.go
@@ -70,6 +70,11 @@ func fixSilentlySkippedSlashes(
 		}
 		currentStake := validator.TokensFromShares(delegation.GetShares())
 
+		// no inflation residue at all → clamp impossible, skip slash-event iteration for entries on healthy state
+		if !info.Stake.GT(currentStake) {
+			return false
+		}
+
 		expectedStake := info.Stake
 		hasEvents := false
 		distrKeeper.IterateValidatorSlashEventsBetween(ctx, val, info.Height, endingHeight,

--- a/app/upgrades/v8_1/distribution.go
+++ b/app/upgrades/v8_1/distribution.go
@@ -17,18 +17,22 @@ type stakingView interface {
 	Delegation(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (stakingtypes.DelegationI, error)
 }
 
+// fixSilentlySkippedSlashes patches DelegatorStartingInfo.Stake by the residue
+// not explained by recorded ValidatorSlashEvents. Recorded slashes are handled
+// at withdraw time, so info.Stake > currentStake alone is not enough to clamp.
 func fixSilentlySkippedSlashes(
 	ctx sdk.Context,
 	stakingKeeper stakingView,
 	distrKeeper distrkeeper.Keeper,
 ) error {
 	logger := ctx.Logger()
+	endingHeight := uint64(ctx.BlockHeight())
 
 	type fix struct {
-		val   sdk.ValAddress
-		del   sdk.AccAddress
-		info  distrtypes.DelegatorStartingInfo
-		stake math.LegacyDec
+		val      sdk.ValAddress
+		del      sdk.AccAddress
+		info     distrtypes.DelegatorStartingInfo
+		newStake math.LegacyDec
 	}
 	var fixes []fix
 	var iterErr error
@@ -44,7 +48,6 @@ func fixSilentlySkippedSlashes(
 			return true
 		}
 		if validator == nil {
-			// orphaned starting info — skip, can't compute currentStake.
 			logger.Warn(
 				"v8.1.0: validator missing for delegator starting info; skipping",
 				"validator", val.String(),
@@ -66,9 +69,30 @@ func fixSilentlySkippedSlashes(
 			return false
 		}
 		currentStake := validator.TokensFromShares(delegation.GetShares())
-		if info.Stake.GT(currentStake) {
-			fixes = append(fixes, fix{val: val, del: del, info: info, stake: currentStake})
+
+		expectedStake := info.Stake
+		hasEvents := false
+		distrKeeper.IterateValidatorSlashEventsBetween(ctx, val, info.Height, endingHeight,
+			func(_ uint64, ev distrtypes.ValidatorSlashEvent) bool {
+				hasEvents = true
+				expectedStake = expectedStake.MulTruncate(
+					math.LegacyOneDec().Sub(ev.Fraction))
+				return false
+			})
+
+		if !expectedStake.GT(currentStake) {
+			return false
 		}
+
+		var newStake math.LegacyDec
+		if hasEvents {
+			ratio := currentStake.Quo(expectedStake)
+			newStake = info.Stake.MulTruncate(ratio)
+		} else {
+			// silent-only residue — exact assignment, no rounding drift.
+			newStake = currentStake
+		}
+		fixes = append(fixes, fix{val: val, del: del, info: info, newStake: newStake})
 		return false
 	})
 	if iterErr != nil {
@@ -77,13 +101,13 @@ func fixSilentlySkippedSlashes(
 
 	for _, f := range fixes {
 		logger.Info(
-			"v8.1.0: clamping delegator starting info stake",
+			"v8.1.0: clamping silent-skip residue on delegator starting info",
 			"validator", f.val.String(),
 			"delegator", f.del.String(),
 			"old_stake", f.info.Stake.String(),
-			"new_stake", f.stake.String(),
+			"new_stake", f.newStake.String(),
 		)
-		f.info.Stake = f.stake
+		f.info.Stake = f.newStake
 		if err := distrKeeper.SetDelegatorStartingInfo(ctx, f.val, f.del, f.info); err != nil {
 			return err
 		}

--- a/app/upgrades/v8_1/distribution_test.go
+++ b/app/upgrades/v8_1/distribution_test.go
@@ -128,6 +128,50 @@ func TestFixSilentlySkippedSlashes_NoEntries(t *testing.T) {
 	require.NoError(t, fixSilentlySkippedSlashes(ctx, sk, k))
 }
 
+func setSlashEvent(t *testing.T, k distrkeeper.Keeper, ctx sdk.Context, val stakingtypes.Validator, fraction string) {
+	t.Helper()
+	valAddr, _ := sdk.ValAddressFromBech32(val.GetOperator())
+	require.NoError(t, k.SetValidatorSlashEvent(ctx, valAddr,
+		uint64(ctx.BlockHeight()), 1,
+		disttypes.NewValidatorSlashEvent(1, math.LegacyMustNewDecFromStr(fraction))))
+}
+
+// Recorded slash fully explains info.Stake > currentStake → clamp is a no-op.
+func TestFixSilentlySkippedSlashes_RecordedSlashLeftAlone(t *testing.T) {
+	k, sk, ctx := setup(t)
+
+	val, delAddr, del := makeDelegation(t, 0, math.NewInt(1000))
+	preStake := val.TokensFromShares(del.Shares)
+	val.Tokens = math.NewInt(950) // 5% recorded slash
+
+	setStartingStake(t, k, ctx, val, delAddr, preStake)
+	setSlashEvent(t, k, ctx, val, "0.05")
+	expectLookup(sk, val, delAddr, del)
+
+	require.NoError(t, fixSilentlySkippedSlashes(ctx, sk, k))
+	require.True(t, getStartingStake(t, k, ctx, val, delAddr).Equal(preStake))
+}
+
+// Recorded 5% + silent 1%: clamp by silent residual only.
+func TestFixSilentlySkippedSlashes_PartialSilentSkipResidue(t *testing.T) {
+	k, sk, ctx := setup(t)
+
+	val, delAddr, del := makeDelegation(t, 0, math.NewInt(1000))
+	preStake := val.TokensFromShares(del.Shares)
+	val.Tokens = math.NewInt(940) // 5% recorded + ~1% silent
+	cur := val.TokensFromShares(del.Shares)
+
+	setStartingStake(t, k, ctx, val, delAddr, preStake)
+	setSlashEvent(t, k, ctx, val, "0.05")
+	expectLookup(sk, val, delAddr, del)
+
+	require.NoError(t, fixSilentlySkippedSlashes(ctx, sk, k))
+
+	expected := preStake.MulTruncate(math.LegacyMustNewDecFromStr("0.95"))
+	want := preStake.MulTruncate(cur.Quo(expected))
+	require.True(t, getStartingStake(t, k, ctx, val, delAddr).Equal(want))
+}
+
 // staking read errors must propagate, not be swallowed.
 func TestFixSilentlySkippedSlashes_PropagatesValidatorErr(t *testing.T) {
 	k, sk, ctx := setup(t)

--- a/app/upgrades/v8_1/distribution_test.go
+++ b/app/upgrades/v8_1/distribution_test.go
@@ -130,7 +130,8 @@ func TestFixSilentlySkippedSlashes_NoEntries(t *testing.T) {
 
 func setSlashEvent(t *testing.T, k distrkeeper.Keeper, ctx sdk.Context, val stakingtypes.Validator, fraction string) {
 	t.Helper()
-	valAddr, _ := sdk.ValAddressFromBech32(val.GetOperator())
+	valAddr, err := sdk.ValAddressFromBech32(val.GetOperator())
+	require.NoError(t, err)
 	require.NoError(t, k.SetValidatorSlashEvent(ctx, valAddr,
 		uint64(ctx.BlockHeight()), 1,
 		disttypes.NewValidatorSlashEvent(1, math.LegacyMustNewDecFromStr(fraction))))

--- a/app/upgrades/v8_1/upgrades.go
+++ b/app/upgrades/v8_1/upgrades.go
@@ -18,7 +18,7 @@ func CreateUpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(c context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
-		ctx.Logger().Info("Starting v8.1.0 upgrade...")
+		ctx.Logger().Info("Starting v8.1.1 upgrade...")
 
 		// Repair before RunMigrations so reward-touching migrations don't panic.
 		ctx.Logger().Info("Repairing distribution state for silently-skipped slashes...")
@@ -32,7 +32,7 @@ func CreateUpgradeHandler(
 			return vm, err
 		}
 
-		ctx.Logger().Info("Upgrade v8.1.0 complete")
+		ctx.Logger().Info("Upgrade v8.1.1 complete")
 		return vm, nil
 	}
 }


### PR DESCRIPTION
this change should have been included in https://github.com/MANTRA-Chain/mantrachain/commit/911395f7a54a5dbe73262ccf16952c256dcb3104, [ValidatorSlashEvents](https://github.com/cosmos/cosmos-sdk/blob/v0.53.6/x/distribution/keeper/delegation.go#L138) are already applied to `info.Stake` at withdraw time, migration can't pre-clamp it in lockstep with currentStake or the slash factor gets applied twice, for test [info](https://github.com/MANTRA-Chain/mantrachain-e2e/commit/663911fd504185f6da35145844ad45286fff8290).