### PR TITLE
[release/v0.6.x] backport CVE-2025-61595: clamp before-send hook gas to remaining

### DIFF
--- a/x/tokenfactory/keeper/before_send.go
+++ b/x/tokenfactory/keeper/before_send.go
@@ -124,7 +124,8 @@ func (k Keeper) callBeforeSendListener(ctx context.Context, from, to sdk.AccAddr
 			if err != nil {
 				return err
 			}
-			childCtx := c.WithGasMeter(types.NewProxyGasMeter(c.GasMeter(), types.BeforeSendHookGasLimit))
+			newGasLimit := min(types.BeforeSendHookGasLimit, c.GasMeter().GasRemaining())
+			childCtx := c.WithGasMeter(types.NewProxyGasMeter(c.GasMeter(), newGasLimit))
 			_, err = k.contractKeeper.Sudo(childCtx, cwAddr, msgBz)
 			if err != nil {
 				return errorsmod.Wrapf(err, "failed to call before send hook for denom %s", coin.Denom)


### PR DESCRIPTION
Backport of [`30d36c46`](https://github.com/MANTRA-Chain/mantrachain/commit/30d36c46e9823b56b8f0dcbb66e980ca5df284e4) ("fix: None (#437)", CVE-2025-61595) to `release/v0.6.x`, per the maintainer-of-record invitation in #653.

The upstream change tightens the child gas meter in `callBeforeSendListener` so a `Sudo` hook can't burn more gas than the parent context still has, by clamping the limit to `min(BeforeSendHookGasLimit, GasRemaining())`.

Adaptation for `release/v0.6.x` (security logic preserved verbatim — this is not a "use a slightly different fix"):

- v0.6.x calls `types.NewProxyGasMeter(c.GasMeter(), <limit>)` (proxy-meter constructor) where master-era code calls `types2.NewGasMeter(<limit>)`. I kept the existing `NewProxyGasMeter` call, replacing only the `<limit>` arg with the clamped `newGasLimit`.
- Master's surrounding refactor (`em := sdk.NewEventManager()` + `WithEventManager(em)`) is unrelated to the gas-clamp fix and was dropped — `release/v0.6.x` doesn't carry that wrapper.
- `min` is the Go 1.21 builtin; `go.mod` on this branch is at `go 1.23.8`.

Cherry-picked with `git cherry-pick -x`; original author (`@freeelancer`) preserved; `(cherry picked from commit …)` trailer included.

Closes #653.