### PR TITLE
docs: add RPC latency benchmark to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Mantrachain is a global real-world assets platform built on blockchain technolog
 - [Architecture](#architecture)
 - [Modules](#modules)
 - [Security](#security)
+- [Resources](#resources)
 
 ## Overview
 
@@ -112,6 +113,10 @@ Please refer to our [Security Policy](SECURITY.md) for more details on reporting
 
 
 
+
+## Resources
+
+- [RPC Latency Benchmark](https://openchainbench.com/benchmarks/mantrachain-rpc) — independent latency and availability measurements for MANTRA Chain public RPC endpoints
 
 ---
 


### PR DESCRIPTION
Adds a Resources section to the README and Table of Contents pointing to the independent RPC latency benchmark for MANTRA Chain.

[OpenChainBench](https://openchainbench.com) is an open-source benchmark suite that continuously measures latency, availability and block-height freshness across public RPC endpoints. The [MANTRA Chain bench](https://openchainbench.com/benchmarks/mantrachain-rpc) covers the official endpoint alongside community providers (ITRocket, Polkachu), giving node operators and dApp developers objective data to choose the fastest endpoint.

The benchmark probes Tendermint `/status` with anti-cache headers on a 30-second cadence from three geographic regions (US East, EU West, AP Southeast). All code and YAML specs are open source at https://github.com/ChainBench/OpenChainBench.