### PR TITLE
fix: use sudo for rcodesign command in macOS binaries signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           for bin in dist/*darwin*/mantrachaind; do
             found=1
             echo "::group::sign+notarize $bin"
-            rcodesign sign \
+            sudo rcodesign sign \
               --p12-file "$WORK/dev-id.p12" \
               --p12-password-file "$WORK/p12-pw.txt" \
               --code-signature-flags runtime \


### PR DESCRIPTION
`dist/` is written by the goreleaser-cross container running as root, so the binary on disk is root-owned. rcodesign signs in place, which requires write access to that file, so we elevate this call rather than chown/chmod the build output.